### PR TITLE
Fix Linux compilation and adjust tests

### DIFF
--- a/Sources/Networking/Encoders/HTTPHeaderEncoder.swift
+++ b/Sources/Networking/Encoders/HTTPHeaderEncoder.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public protocol HTTPHeaderEncoder {
   func encodeHeaders(for urlRequest: inout URLRequest, with headers: [HTTPHeader])

--- a/Sources/Networking/Encoders/HTTPParameterEncoder.swift
+++ b/Sources/Networking/Encoders/HTTPParameterEncoder.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public protocol HTTPParameterEncoder {
   func encodeParameters(for urlRequest: inout URLRequest, with parameters: [HTTPParameter]) throws

--- a/Sources/Networking/Other/URLSessionTaskProtocol.swift
+++ b/Sources/Networking/Other/URLSessionTaskProtocol.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public protocol URLSessionTaskProtocol: Sendable {
   func data(for request: URLRequest, delegate: URLSessionTaskDelegate?) async throws -> (Data, URLResponse)

--- a/Sources/Networking/Request/Request.swift
+++ b/Sources/Networking/Request/Request.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public protocol Request {
   var httpMethod: HTTPMethod { get }

--- a/Sources/Networking/Request/RequestBuilder.swift
+++ b/Sources/Networking/Request/RequestBuilder.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public protocol RequestBuilder {
   func setHttpMethod(_ method: HTTPMethod) -> RequestBuilder

--- a/Sources/Networking/Request/RequestFactory.swift
+++ b/Sources/Networking/Request/RequestFactory.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public protocol RequestFactory {
   func build(

--- a/Sources/Networking/Util/Downloader/FileDownloadable.swift
+++ b/Sources/Networking/Util/Downloader/FileDownloadable.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public protocol FileDownloadable {
   func downloadFile(with url: URL) async throws -> URL

--- a/Sources/Networking/Util/Downloader/ImageDownloadable.swift
+++ b/Sources/Networking/Util/Downloader/ImageDownloadable.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 #if canImport(UIKit)
   import UIKit
@@ -8,6 +11,8 @@ import Foundation
   import AppKit
 
   public typealias PlatformImage = NSImage
+#else
+  public typealias PlatformImage = Data
 #endif
 
 public protocol ImageDownloadable {
@@ -48,9 +53,13 @@ public struct ImageDownloader: ImageDownloadable, Sendable {
   }
 
   private func getImage(from data: Data) throws -> PlatformImage {
+    #if canImport(UIKit) || canImport(AppKit)
     guard let image = PlatformImage(data: data) else {
       throw NetworkingError.internalError(.invalidImageData)
     }
     return image
+    #else
+    return data
+    #endif
   }
 }

--- a/Sources/Networking/Util/Performers/AsyncRequestPerformable.swift
+++ b/Sources/Networking/Util/Performers/AsyncRequestPerformable.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 #if canImport(UIKit)
   import UIKit

--- a/Sources/Networking/Validator/ResponseValidator.swift
+++ b/Sources/Networking/Validator/ResponseValidator.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public protocol ResponseValidator: Sendable {
   func validateNoError(_ error: Error?) throws

--- a/Tests/NetworkingTests/Encoders/HTTPHeaderEncoderTests.swift
+++ b/Tests/NetworkingTests/Encoders/HTTPHeaderEncoderTests.swift
@@ -1,5 +1,7 @@
 import XCTest
-
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 @testable import AAONetworking
 
 final class HTTPHeaderEncoderTests: XCTestCase {

--- a/Tests/NetworkingTests/Encoders/HTTPParameterEncoderTests.swift
+++ b/Tests/NetworkingTests/Encoders/HTTPParameterEncoderTests.swift
@@ -1,5 +1,7 @@
 import XCTest
-
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 @testable import AAONetworking
 
 final class HTTPParameterEncoderTests: XCTestCase {

--- a/Tests/NetworkingTests/Mocks/Mock-JSON.swift
+++ b/Tests/NetworkingTests/Mocks/Mock-JSON.swift
@@ -13,3 +13,5 @@ let invalidMockPersonJsonData: Data = """
       "Age": 30
   }
   """.data(using: .utf8)!
+
+let mockImageData: Data = Data(base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/3h58iQAAAAASUVORK5CYII=")!

--- a/Tests/NetworkingTests/Mocks/MockURLResponseValidator.swift
+++ b/Tests/NetworkingTests/Mocks/MockURLResponseValidator.swift
@@ -1,5 +1,8 @@
 import AAONetworking
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 struct MockURLResponseValidator: ResponseValidator {
   var throwError: NetworkingError? = nil

--- a/Tests/NetworkingTests/Mocks/MockURLSession.swift
+++ b/Tests/NetworkingTests/Mocks/MockURLSession.swift
@@ -1,5 +1,8 @@
 import AAONetworking
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 final class MockURLSession: URLSessionTaskProtocol {
   var url: URL?
@@ -60,10 +63,10 @@ final class MockURLSession: URLSessionTaskProtocol {
     }
     self.url = url
 
-    guard let data, let url = self.url else {
+    guard let data, let urlResponse else {
       throw NetworkingError.internalError(.unknown)
     }
-    return (data, URLResponse(url: url, mimeType: nil, expectedContentLength: 0, textEncodingName: nil))
+    return (data, urlResponse)
   }
 
   func downloadTask(with url: URL, completionHandler: @escaping @Sendable (URL?, URLResponse?, Error?) -> Void) -> URLSessionDownloadTask {

--- a/Tests/NetworkingTests/Request/RequestBuilderTests.swift
+++ b/Tests/NetworkingTests/Request/RequestBuilderTests.swift
@@ -1,5 +1,7 @@
 import XCTest
-
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 @testable import AAONetworking
 
 final class RequestBuilderTests: XCTestCase {

--- a/Tests/NetworkingTests/Request/RequestFactoryTests.swift
+++ b/Tests/NetworkingTests/Request/RequestFactoryTests.swift
@@ -1,5 +1,7 @@
 import XCTest
-
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 @testable import AAONetworking
 
 final class RequestFactoryTests: XCTestCase {

--- a/Tests/NetworkingTests/Request/RequestTests.swift
+++ b/Tests/NetworkingTests/Request/RequestTests.swift
@@ -1,5 +1,7 @@
 import XCTest
-
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 @testable import AAONetworking
 
 final class RequestTests: XCTestCase {

--- a/Tests/NetworkingTests/Util/Downloader/FileDownloadableTests.swift
+++ b/Tests/NetworkingTests/Util/Downloader/FileDownloadableTests.swift
@@ -1,5 +1,7 @@
 import XCTest
-
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 @testable import AAONetworking
 
 final class FileDownloadableTests: XCTestCase {

--- a/Tests/NetworkingTests/Util/Downloader/ImageDownloadableTests.swift
+++ b/Tests/NetworkingTests/Util/Downloader/ImageDownloadableTests.swift
@@ -1,13 +1,21 @@
 import XCTest
-
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 @testable import AAONetworking
 
 final class ImageDownloadableTests: XCTestCase {
   // MARK: test Async/Await
 
-  func testDownloadImageSuccess() async throws { // note: this is an async test as it actually decodes url to generate the image
-    let testURL = URL(string: "https://i.natgeofe.com/n/4f5aaece-3300-41a4-b2a8-ed2708a0a27c/domestic-dog_thumb_square.jpg")!
-    let sut = ImageDownloader()
+  func testDownloadImageSuccess() async throws {
+    let testURL = URL(string: "https://example.com/image.png")!
+    let urlSession = MockURLSession(
+      data: mockImageData,
+      url: testURL,
+      urlResponse: buildResponse(statusCode: 200),
+      error: nil
+    )
+    let sut = ImageDownloader(urlSession: urlSession)
     do {
       _ = try await sut.downloadImage(from: testURL)
       XCTAssertTrue(true)

--- a/Tests/NetworkingTests/Util/Performers/AsyncRequestPerformableTests.swift
+++ b/Tests/NetworkingTests/Util/Performers/AsyncRequestPerformableTests.swift
@@ -1,5 +1,7 @@
 import XCTest
-
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 @testable import AAONetworking
 
 final class AsyncRequestPerformableTests: XCTestCase {

--- a/Tests/NetworkingTests/Validator/ResponseValidatorTests.swift
+++ b/Tests/NetworkingTests/Validator/ResponseValidatorTests.swift
@@ -1,5 +1,7 @@
 import XCTest
-
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 @testable import AAONetworking
 
 final class URLResponseValidatorTests: XCTestCase {
@@ -59,7 +61,13 @@ final class URLResponseValidatorTests: XCTestCase {
   }
 
   func test_validateStatus_givenURLResponse_Throws() throws {
-    XCTAssertThrowsError(try sut.validateStatus(from: URLResponse())) { error in
+    let urlResponse = URLResponse(
+      url: URL(string: "https://example.com")!,
+      mimeType: nil,
+      expectedContentLength: 0,
+      textEncodingName: nil
+    )
+    XCTAssertThrowsError(try sut.validateStatus(from: urlResponse)) { error in
       XCTAssertEqual(error as? NetworkingError, NetworkingError.internalError(.noHTTPURLResponse))
     }
   }


### PR DESCRIPTION
## Summary
- add conditional `FoundationNetworking` imports throughout the library
- support `PlatformImage` on Linux by aliasing to `Data`
- update `MockURLSession` to return provided responses in async calls
- provide mock image data and rewrite image downloader test to avoid real network calls

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6865ef110d7883298e7de20c81c59ab2